### PR TITLE
Fixed blind copy and paste

### DIFF
--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -17,9 +17,9 @@ IBinanceClient.KeepAliveUserDataStream(string userDataListenKey)
 ```
 
 ### `CloseUserDataStream:void`
-Pings a User Data stream to keep it alive. Despite this method returning the `UserDataStreamResponse` type the API currently doesn't return anything.
+Closes a User Data stream.
 ```c#
-IBinanceClient.KeepAliveUserDataStream(string userDataListenKey)
+IBinanceClient.CloseUserDataStream(string userDataListenKey)
 ```
 
 ## General Endpoints


### PR DESCRIPTION
Fixed a blind copy and paste between KeepAliveUserDataStream and CloseUserDataStream. You can add more detail as you'd like.